### PR TITLE
Make a bin and unify option parsing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "spacekit",
   "version": "1.0.0",
   "description": "",
-  "main": "server",
+  "main": "./index.js",
   "scripts": {
-    "server": "node ./server",
-    "relay": "node ./relay",
     "example-server": "node ./examples/server",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "semistandard"
+  },
+  "bin": {
+    "spacekit": "./index.js"
   },
   "repository": {
     "type": "git",

--- a/relay/index.js
+++ b/relay/index.js
@@ -4,10 +4,20 @@ const WebSocket = require('ws');
 const net = require('net');
 const backoff = require('backoff');
 
+/**
+ * A SpaceKitRelay proxies data between a SpaceKitServer and local servers.
+ * Only TLS traffic is proxied; each app server must serve its own certificate.
+ * (The SpaceKitServer does allow ACME (LetsEncrypt) traffic through.)
+ *
+ *     [SpaceKitServer] <------ws-------- [SpaceKitRelay]
+ *             |            internet          /   \
+ *             |                             /     \
+ *          client                       tls-app  tls-app
+ */
 class SpaceKitRelay {
   constructor (argv) {
     this.argv = argv;
-    this.url = `wss://${argv.server}/`;
+    this.url = `wss://${argv.endpoint}/`;
 
     this.outgoingSockets = new Map();
 
@@ -95,23 +105,3 @@ class SpaceKitRelay {
 }
 
 module.exports = SpaceKitRelay;
-
-if (require.main === module) {
-  const argv = require('yargs')
-    .usage('Usage: npm run relay -- --hostname HOSTNAME')
-    .help('h')
-    .options('server', {
-      describe: 'the spacekit server hostname',
-      default: 'api.spacekit.io'
-    })
-    .options('port', {
-      describe: 'the port your application server is listening on',
-      default: 443
-    })
-    .options('hostname', {
-      describe: 'the hostname of this server, e.g. "home.mcav.spacekit.io"',
-      demand: true
-    })
-    .argv;
-  module.exports.instance = new SpaceKitRelay(argv);
-}

--- a/server/dynamic-dns.js
+++ b/server/dynamic-dns.js
@@ -1,10 +1,16 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+
+// TODO: configure these via a command-line flag instead
 AWS.config.credentials = new AWS.SharedIniFileCredentials({
   profile: 'spacekit'
 });
 
+/**
+ * A wrapper for Amazon Route 53's DNS service, for the sole purpose of
+ * upserting individual hostname records.
+ */
 class DynamicDNS {
 
   constructor (hostedZoneId) {
@@ -26,7 +32,7 @@ class DynamicDNS {
                   Value: recordValue
                 }
               ],
-              TTL: 1
+              TTL: 1 // TODO: make configurable
             }
           }
         ],

--- a/server/web-socket-relay.js
+++ b/server/web-socket-relay.js
@@ -5,11 +5,15 @@ const WebSocket = require('ws');
 
 /**
  * A relay that tunnels multiple sockets into one WebSocket.
- * This is the server-side protocol of the relay that runs
+ * This is the server-side protocol of the relay that runs behind the firewall
  * on the client machine.
  *
- * Raw TCP streams are forwarded into the webSocket using
- * custom JSON messages like 'open', 'data', and 'close'.
+ * Raw TCP streams are forwarded into the websocket using a simple protocol:
+ *
+ * socket.send(jsonHeader); // sent as string
+ * socket.send(binaryBody); // sent as binary
+ *
+ * For now, these messages just proxy socket messages ('open', 'data', 'close').
  */
 class WebSocketRelay {
 


### PR DESCRIPTION
This adds "./index.js" as an NPM bin (so you can run `$ spacekit` after `npm link`) and pushes out option parsing to that file. Also some comment fixes/cleanup.

r? @jedireza 
