### PR TITLE
redirect root domain requests to web server

### DIFF
--- a/service/index.js
+++ b/service/index.js
@@ -95,7 +95,8 @@ class SpaceKitService {
       if (relay) {
         relay.addSocket(socket, hostname, 443);
       } else {
-        socket.end();
+        let message = 'Relay not connected';
+        socket.end(`HTTP/1.1 500 ${message}\r\n\r\n${message}`);
       }
     }
   }
@@ -114,7 +115,11 @@ class SpaceKitService {
   handleNetConnection (socket, hostname, path) {
     console.log('new Net connection', hostname);
 
-    if (hostname === this.apiHostname || hostname === this.webHostname) {
+    if (hostname === this.config.host) {
+      let response = 'HTTP/1.1 301 Moved Permanently\r\n' +
+                     `Location: https://${this.webHostname}${path}\r\n\r\n`;
+      socket.end(response);
+    } else if (hostname === this.apiHostname || hostname === this.webHostname) {
       let response = 'HTTP/1.1 301 Moved Permanently\r\n' +
                      `Location: https://${hostname}${path}\r\n\r\n`;
       socket.end(response);
@@ -128,7 +133,7 @@ class SpaceKitService {
       if (relay) {
         relay.addSocket(socket, hostname, 80);
       } else {
-        let message = 'No relays available';
+        let message = 'Relay not connected';
         socket.end(`HTTP/1.1 500 ${message}\r\n\r\n${message}`);
       }
     }


### PR DESCRIPTION
I was going to redirect secure root domain requests (ex: `https://spacekit.io` => `https://www.spacekit.io`), but that would require us to terminate yet another certificate just to do the redirect. Not a big deal imo.
