### PR TITLE
Save config and certs under ~/.spacekit

### DIFF
--- a/bin/spacekit.js
+++ b/bin/spacekit.js
@@ -10,8 +10,9 @@ const Path = require('path');
 const PortMap = require('../lib/port-map');
 const Promptly = require('promptly');
 const Request = require('request');
+const MkdirP = require('mkdirp');
 
-let configPath = Path.resolve(Os.homedir(), 'spacekit.json');
+let configPath = Path.resolve(Os.homedir(), '.spacekit/config.json');
 let config = {
   service: 'api',
   host: 'spacekit.io',
@@ -308,6 +309,7 @@ function configure () {
 function saveConfig () {
   let contents = JSON.stringify(config, undefined, 2);
 
+  MkdirP.sync(Path.resolve(Os.homedir(), '.spacekit'));
   Fs.writeFile(configPath, contents, (err) => {
     if (err) {
       console.log('Error: saving config failed');

--- a/lib/tls-certificate.js
+++ b/lib/tls-certificate.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Os = require('os');
+const Path = require('path');
 const Pem = require('pem');
 const Tls = require('tls');
 
@@ -31,7 +33,7 @@ class TlsCertificate {
 
     this.le = LetsEncrypt.create({
       server: LetsEncrypt.productionServerUrl,
-      configDir: './certs',
+      configDir: Path.resolve(Os.homedir(), '.spacekit/certs'),
       privkeyPath: ':config/live/:hostname/privkey.pem',
       fullchainPath: ':config/live/:hostname/fullchain.pem',
       certPath: ':config/live/:hostname/cert.pem',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bunyan": "1.x.x",
     "commander": "2.x.x",
     "letsencrypt": "1.x.x",
+    "mkdirp": "^0.5.1",
     "pem": "1.x.x",
     "promptly": "1.x.x",
     "request": "2.x.x",


### PR DESCRIPTION
This should fix #61 and also store the config under there too rather than a normal file in your homedir.
