### PR TITLE
Add a new line before connection failed message.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ class Relay extends EventEmitter {
 
     this.ws.on('close', () => {
       log.warn('Lost connection to the service.');
-      console.log('Connection to the SpaceKit server failed. Reconnecting...');
+      console.log('\nConnection to the SpaceKit server failed. Reconnecting...');
       this.maybeReconnect();
     });
 


### PR DESCRIPTION
I'm not sure why this would run on from the previous line, but I assume this would deal with it. Fixes #62.
